### PR TITLE
Update from manifest v2 to manifest v3

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -43,6 +43,13 @@ module.exports = function (defaults) {
       includePolyfill: true,
     },
 
+    // Chromium forbids the use of eval in browser extensions as of Manifest v3.
+    // This setting causes ember-auto-import to avoid webpack source map settings
+    // which would implicitly use eval in built versions of the app.
+    autoImport: {
+      forbidEval: true,
+    },
+
     sourcemaps: {
       enabled: !IS_TEST_ENVIRONMENT,
     },

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -21,7 +21,7 @@ const assetsPathFor = (assetsRelativePath) => {
 const manifest = Object.assign(
   {
     version: packageJson.version,
-    manifest_version: 2,
+    manifest_version: 3,
     content_scripts: [
       {
         matches: ['*://www.pathofexile.com/trade*'],
@@ -30,11 +30,14 @@ const manifest = Object.assign(
       },
     ],
     background: {
-      scripts: ['background.js'],
-      persistent: true,
+      service_worker: 'background.js',
     },
-    permissions: ['storage', '*://poe.ninja/*'],
-    web_accessible_resources: [assetsPathFor('images/*')],
+    permissions: ['storage'],
+    host_permissions: ['*://poe.ninja/*'],
+    web_accessible_resources: [{
+      resources: [assetsPathFor('images/*')],
+      matches: ['*://www.pathofexile.com/*']
+    }],
     icons: {
       16: 'icon16.png',
       48: 'icon48.png',

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -34,10 +34,12 @@ const manifest = Object.assign(
     },
     permissions: ['storage'],
     host_permissions: ['*://poe.ninja/*'],
-    web_accessible_resources: [{
-      resources: [assetsPathFor('images/*')],
-      matches: ['*://www.pathofexile.com/*']
-    }],
+    web_accessible_resources: [
+      {
+        resources: [assetsPathFor('images/*')],
+        matches: ['*://www.pathofexile.com/*'],
+      },
+    ],
     icons: {
       16: 'icon16.png',
       48: 'icon48.png',


### PR DESCRIPTION
This PR updates the extension from Manifest v2 to Manifest v3. This will avoid the extension breaking in January 2023, when [Chrome intends to drop support for v2 extensions](https://developer.chrome.com/docs/extensions/mv3/mv2-sunset/).

To do this, I followed Chrome's [migration guide](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/) and double checked its [migration checklist](https://developer.chrome.com/docs/extensions/mv3/mv3-migration-checklist/).

This was a pretty simple transition because `better-trading` makes very minimal use of its background page; it was already event-based and required no code changes to adapt to becoming a service worker. Most of the changes are trivial updates to the manifest generation script.

The only real interesting change was the new `ember-cli-build.js` setting that's become required with Manifest v3's new security requirements that forbid the use of `eval` by extensions. Previously, in dev builds of the extension, `ember-auto-import` would by default use webpack settings for source map generation that resulted in `eval` appearing implicitly in the dev js bundle. The new `forbidEval` setting forces `ember-auto-import` not to do that so that the dev extension can load successfully in mv3 mode.

Verified by:
* running `make test`
* smoke testing that a dev build of the extension (`make dev`) loaded and appeared functional
* smoke testing that a prod build of the extension (`make package-chrome`) loaded and appeared functional