### PR TITLE
Fix pinning

### DIFF
--- a/app/services/item-results/enhancers/pinnable.ts
+++ b/app/services/item-results/enhancers/pinnable.ts
@@ -71,6 +71,10 @@ export default class Pinnable extends Service implements ItemResultsEnhancerServ
 
   private renderPinButton(): HTMLElement {
     const element = window.document.createElement('button');
+    // standard button styles from pathofexile.com
+    element.classList.add('btn');
+    element.classList.add('btn-default');
+    // our style overrides
     element.classList.add('bt-pin-button');
     element.innerHTML = `
       <span class="bt-pin-button-unpinned">
@@ -82,7 +86,11 @@ export default class Pinnable extends Service implements ItemResultsEnhancerServ
     `;
     element.addEventListener('click', this.handlePinClick.bind(this));
 
-    return element;
+    // for consistency with sibling button layouts/styling
+    const wrapper = window.document.createElement('span');
+    wrapper.appendChild(element);
+
+    return wrapper;
   }
 
   private createPinnedItem(id: string, result: HTMLElement): ItemResultsPinnedItem | null {

--- a/app/services/item-results/enhancers/pinnable.ts
+++ b/app/services/item-results/enhancers/pinnable.ts
@@ -24,7 +24,7 @@ export default class Pinnable extends Service implements ItemResultsEnhancerServ
   pinnedItems: PinnedItemsMap = {};
 
   enhance(itemElement: HTMLElement) {
-    const detailsElement = itemElement.querySelector('.details .pull-left');
+    const detailsElement = itemElement.querySelector('.details .btns');
     if (!detailsElement) return;
 
     detailsElement.appendChild(this.renderPinButton());

--- a/app/styles/globals/_pinnable.scss
+++ b/app/styles/globals/_pinnable.scss
@@ -21,6 +21,10 @@
 }
 
 .bt-pin-button {
+  // This ensures the button is big enough to fit the "Unpin" text
+  // without resizing when toggling between pin and unpin
+  min-width: 47px !important;
+
   .bt-pin-button-pinned {
     display: none;
   }

--- a/app/styles/globals/_pinnable.scss
+++ b/app/styles/globals/_pinnable.scss
@@ -20,35 +20,7 @@
   }
 }
 
-.results.compact {
-  .bt-pin-button {
-    height: 18px;
-    border-color: #444;
-    line-height: 16px;
-  }
-}
-
 .bt-pin-button {
-  padding: 1px 5px;
-  border: 1px solid transparent;
-  border-radius: 0;
-  margin: 8px 0 0;
-  background-color: #222;
-  text-align: center;
-  font-size: 12px;
-  font-weight: normal;
-  line-height: 1.5;
-  color: #e9cf9f;
-  cursor: pointer;
-  vertical-align: middle;
-
-  &:focus,
-  &:hover {
-    border-color: #444;
-    background-color: #090909;
-    outline: none;
-  }
-
   .bt-pin-button-pinned {
     display: none;
   }


### PR DESCRIPTION
Based on Chrome store reviews, it looks like the `pinnable` enhancer broke sometime in May. It looks like the issue was that the container element that the enhancer attempts to inject its button into changed the name of a style we used to query for it (from `.details .pull-left` to `.details .btns`).

This PR adjusts the selector to put our Pin button in the expected place.

It looked like the styling was a bit off from the other nearby buttons - presumably the source page styling we were matching changed slightly alongside the change that broke us. I adjusted the styling such that our button reuses the same `btn` and `btn-default` classes used by the other sibling buttons and uses a wrapping `<span>` element similar to the other buttons to match their margin behavior, and then eliminated our slightly-broken copies of those styles.

Finally, to avoid an issue where the button's width changes between the "Pin" and "Unpin" states (since the text has different length) and the layout shifts around at certain breakpoints when toggling states because of the width difference, I added a `min-width` corresponding to the "Unpin" state so that the button remains the same size between states. This is a best-effort thing - it might not fix the layout shifts for users that use fonts besides the standard english Windows+Chrome one I'm testing against, but it should slightly improve the common case and it's not *that* bad for the cases where it doesn't help.

The flexbox behavior with the other buttons feels a little janky because the existing buttons are a little janky; the buttons are contained in a flexbox with `space-between`, but the "direct whisper" button with its dropdown has `margin-right: auto`, so the buttons have inconsistent spacing behavior already that becomes even weirder feeling with our new button. But it works reasonably well at what I expect to be the most common use scenario (compact layout at browser width > ~1280px) so I don't feel inclined to mess with it too much.

Before (missing button):
![screenshot highlighting button group with no pin button](https://user-images.githubusercontent.com/376284/190053928-ed942a3e-b152-4256-b1c8-9d555437a79c.png)

After (button exists and works as expected):
![animation demonstrating pin button behavior in different sizes and layouts](https://user-images.githubusercontent.com/376284/190053724-7ec3cca8-274d-42a2-8ade-341bebbca2de.gif)

